### PR TITLE
fix a couple of old securititas references

### DIFF
--- a/noggin_messages/__init__.py
+++ b/noggin_messages/__init__.py
@@ -6,7 +6,7 @@ class MemberSponsorV1(message.Message):
 
     topic = "fas.group.member.sponsor"
     body_schema = {
-        "id": "http://fedoraproject.org/message-schema/securtitas",
+        "id": "http://fedoraproject.org/message-schema/noggin",
         "$schema": "http://json-schema.org/draft-04/schema#",
         "description": "The message sent when a user is added to a group by a sponsor",
         "type": "object",
@@ -31,7 +31,7 @@ class UserCreateV1(message.Message):
 
     topic = "fas.user.create"
     body_schema = {
-        "id": "http://fedoraproject.org/message-schema/securtitas",
+        "id": "http://fedoraproject.org/message-schema/noggin",
         "$schema": "http://json-schema.org/draft-04/schema#",
         "description": "The message sent when a user is created",
         "type": "object",


### PR DESCRIPTION
last bit of renaming work. securitas was misspelled originally, so we
missed these ones

Signed-off-by: Ryan Lerch <rlerch@redhat.com>