### PR TITLE
Use poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ authorized_licenses = [
 
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ authorized_licenses = [
 
 
 [build-system]
-requires = ["poetry>=1.0.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
poetry-core is all that is needed.  This loosens build requirements so builds are possible against EPEL9 where `poetry-core` is package but `poetry` is not.